### PR TITLE
Create pymerkle.proof.proof from dicts and JSON

### DIFF
--- a/pymerkle/proof.py
+++ b/pymerkle/proof.py
@@ -54,31 +54,49 @@ class proof(object):
     :ivar body.proof_path:        (*list of (+1/-1, str)*) See the homonymous argument of the constructor
     """
 
-    def __init__(
-            self,
-            generation,
-            provider,
-            hash_type,
-            security,
-            encoding,
-            proof_index,
-            proof_path):
-        self.header = {
-            'uuid': str(uuid.uuid1()),    # Time based proof id
-            'generation': generation,
-            'timestamp': int(time.time()),
-            'creation_moment': time.ctime(),
-            'provider': provider,
-            'hash_type': hash_type,
-            'encoding': encoding,
-            'security': security,
-            'status': None               # Will change to True or False after validation
-        }
+    def __init__(self, *args, **kwargs):
+        if args:                                    # Assuming positional arguments by default
+            self.header = {
+                'uuid': str(uuid.uuid1()),      # Time based proof idW
+                'timestamp': int(time.time()),
+                'creation_moment': time.ctime(),
+                'generation': args[0],
+                'provider': args[1],
+                'hash_type': args[2],
+                'security': args[3],
+                'encoding': args[4],
+                'status': None                  # Will change to True or False after validation
+            }
 
-        self.body = {
-            'proof_index': proof_index,
-            'proof_path': proof_path
-        }
+            self.body = {
+                'proof_index': args[5],
+                'proof_path': args[6]
+            }
+        else:
+            if kwargs.get('from_dict'):             # Importing proof from dict
+                self.header = kwargs.get('from_dict')['header']
+                self.body = kwargs.get('from_dict')['body']
+            elif kwargs.get('from_json'):           # Importing proof from JSON text
+                proof_dict = json.loads(kwargs.get('from_json'))
+                self.header = proof_dict['header']
+                self.body = proof_dict['body']
+            else:                                   # Standard creation of a proof
+                self.header = {
+                    'uuid': str(uuid.uuid1()),      # Time based proof idW
+                    'timestamp': int(time.time()),
+                    'creation_moment': time.ctime(),
+                    'generation': kwargs.get('generation'),
+                    'provider': kwargs.get('provider'),
+                    'hash_type': kwargs.get('hash_type'),
+                    'security': kwargs.get('security'),
+                    'encoding': kwargs.get('encoding'),
+                    'status': None                  # Will change to True or False after validation
+                }
+
+                self.body = {
+                    'proof_index': kwargs.get("proof_index"),
+                    'proof_path': kwargs.get("proof_path")
+                }
 
     def __repr__(self):
         """Overrides the default implementation.


### PR DESCRIPTION
This pull request slightly modifies the constructor to receive keyword arguments and remove the dependency on positional arguments to add two new types of keyword arguments `from_dict` and `from_json`.  Thus. a `pymerkle.proof.proof` object can be created from a JSON string (using `from_json`) or a dict directly (using `from_dict`) or even using positional arguments and standard keyword arguments as usual.

The goal is to make it easier the process of validating proofs stored as JSON objects when taken from dicts or JSON files.

Taken the example in `README.md` as a reference, a sample verification is defined as follows
```
from pymerkle import *

tree = merkle_tree()

validator = proof_validator()     # Create object for validating proofs

# Successively update the tree with one hundred records
for i in range(10):
    tree.update(bytes('{}-th record'.format(i), 'utf-8'))

p = tree.audit_proof(b'1-th record') # Generate audit-proof for the given record
p

from pymerkle.proof import proof

r1 = proof(from_json=p.JSONstring())
validate_proof(target_hash=tree.root_hash(), proof=r1) # bool

import json
r2 = proof(from_dict=json.loads(p.JSONstring()))
validate_proof(target_hash=tree.root_hash(), proof=r2) # bool

r3 = proof(
    p.header["generation"],
    p.header["provider"],
    p.header["hash_type"],
    p.header["security"],
    p.header["encoding"],
    p.body["proof_index"],
    p.body["proof_path"]
)

validate_proof(target_hash=tree.root_hash(), proof=r3) # bool
```

Tests are still passed succesfully:

```
===================================== 18679 passed in 36.79 seconds =====================================
```