### PR TITLE
Add bytes hashing without encoding

### DIFF
--- a/pymerkle/proof.py
+++ b/pymerkle/proof.py
@@ -51,6 +51,7 @@ class Proof(object):
     :ivar header.hash_type:       (*str*) Hash type of the provider Merkle-tree
     :ivar header.encoding:        (*str*) Encoding type of the provider Merkle-tree
     :ivar header.security:        (*bool*) Security mode of the provider Merkle-tree
+    :param raw_bytes:             (*bool*) Whether the machine of the Merkle-tree will accept binary data.
     :ivar header.status:          (*bool*) ``True`` resp. ``False`` if the proof has been found to be *valid*, resp. *invalid*
                                   after the last validation. If no validation has yet been performed, then it is ``None``.
     :ivar body:                   (*dict*) Contains the keys *proof_index*, *proof_path* (see below)
@@ -69,6 +70,7 @@ class Proof(object):
                 'hash_type': args[1],
                 'encoding': args[2],
                 'security': args[3],
+                'raw_bytes': kwargs.get("raw_bytes", False),
                 'status': None                                                  # Will change to True or False after validation
             }
 
@@ -81,7 +83,6 @@ class Proof(object):
                 self.header = kwargs.get('from_dict')['header']
 
                 encoding = self.header['encoding']
-
                 _body = kwargs.get('from_dict')['body']
                 self.body = {
                     'proof_index': _body['proof_index'],
@@ -109,6 +110,7 @@ class Proof(object):
                     'hash_type': kwargs.get('hash_type'),
                     'encoding': kwargs.get('encoding'),
                     'security': kwargs.get('security'),
+                    'raw_bytes': kwargs.get("raw_bytes", False),
                     'status': None                                              # Will change to True or False after validation
                 }
 
@@ -136,6 +138,7 @@ class Proof(object):
                 \n    hash-type   : {hash_type}\
                 \n    encoding    : {encoding}\
                 \n    security    : {security}\
+                \n    raw_bytes   : {raw_bytes}\
                 \n\
                 \n    proof-index : {proof_index}\
                 \n    proof-path  :\
@@ -153,6 +156,7 @@ class Proof(object):
                     hash_type=self.header['hash_type'].upper().replace('_', '-'),
                     encoding=self.header['encoding'].upper().replace('_', '-'),
                     security='ACTIVATED' if self.header['security'] else 'DEACTIVATED',
+                    raw_bytes=self.header['raw_bytes'],
                     proof_index=self.body['proof_index'],
                     proof_path=stringify_path(self.body['proof_path'], self.header['encoding']),
                     status='UNVALIDATED' if self.header['status'] is None else 'VALID' if self.header['status'] is True else 'NON VALID'

--- a/pymerkle/serializers.py
+++ b/pymerkle/serializers.py
@@ -17,6 +17,7 @@ class MerkleTreeSerializer(json.JSONEncoder):
             encoding = obj.encoding
             security = obj.security
             leaves = obj.leaves
+            raw_bytes = obj.raw_bytes
 
         except TypeError:
             return json.JSONEncoder.default(self, obj)        # let TypeError get raised
@@ -26,6 +27,7 @@ class MerkleTreeSerializer(json.JSONEncoder):
                 'header': {
                     'hash_type': hash_type,
                     'encoding': encoding,
+                    'raw_bytes': raw_bytes,
                     'security': security},
                     'hashes': [leaf.digest.decode(encoding=encoding) for leaf in leaves]
             }
@@ -93,6 +95,7 @@ class ProofSerializer(json.JSONEncoder):
             hash_type = obj.header['hash_type']
             encoding = obj.header['encoding']
             security = obj.header['security']
+            raw_bytes = obj.header['raw_bytes']
             proof_index = obj.body['proof_index']
             proof_path = obj.body['proof_path']
             status = obj.header['status']
@@ -111,6 +114,7 @@ class ProofSerializer(json.JSONEncoder):
                     'hash_type': hash_type,
                     'encoding': encoding,
                     'security': security,
+                    'raw_bytes': raw_bytes,
                     'status': status
                 },
                 'body': {
@@ -119,7 +123,7 @@ class ProofSerializer(json.JSONEncoder):
 
                         [
                             sign,
-                            hash if type(hash) is str else hash.decode(encoding=encoding)
+                            hash if type(hash) is str else hash.decode()
 
                         ] for (sign, hash) in proof_path
 

--- a/pymerkle/tree.py
+++ b/pymerkle/tree.py
@@ -32,6 +32,8 @@ class MerkleTree(object):
     :type encoding:   str
     :param security:  [optional] Defaults to ``True``.If ``False``, defense against second-preimage attack will be disabled
     :type security:   bool
+    :param raw_bytes:  [optional] Defaults to ``False``. Specifies whether the machine will accept binary data.
+    :type raw_bytes:   bool
 
     :raises UndecodableRecordError:    if any of the provided ``records`` is a bytes-like object which cannot be decoded with
                                        the provided encoding type
@@ -47,7 +49,8 @@ class MerkleTree(object):
                       implicitly upon a request for consistency proof)
     """
 
-    def __init__(self, *records, hash_type='sha256', encoding='utf-8', security=True):
+    def __init__(self, *records, hash_type='sha256', encoding='utf-8', security=True,
+                 raw_bytes=False):
 
         self.uuid = str(uuid.uuid1())
 
@@ -57,7 +60,8 @@ class MerkleTree(object):
             machine = hash_machine(
                 hash_type=hash_type,
                 encoding=encoding,
-                security=security
+                security=security,
+                raw_bytes=raw_bytes
             )
 
         except (NotSupportedEncodingError, NotSupportedHashTypeError):
@@ -65,6 +69,7 @@ class MerkleTree(object):
 
         self.hash_type  = hash_type.lower().replace('-', '_')
         self.encoding   = encoding.lower().replace('-', '_')
+        self.raw_bytes  = raw_bytes
         self.security   = security
         self.hash       = machine.hash
         self.multi_hash = machine.multi_hash
@@ -385,6 +390,7 @@ class MerkleTree(object):
                 hash_type=self.hash_type,
                 encoding=self.encoding,
                 security=self.security,
+                raw_bytes=self.raw_bytes,
                 proof_index=-1,
                 proof_path=()
             )
@@ -394,6 +400,7 @@ class MerkleTree(object):
                 hash_type=self.hash_type,
                 encoding=self.encoding,
                 security=self.security,
+                raw_bytes=self.raw_bytes,
                 proof_index=proof_index,
                 proof_path=audit_path
             )
@@ -974,7 +981,8 @@ class MerkleTree(object):
             _tree = MerkleTree(
                 hash_type=_header['hash_type'],
                 encoding=_header['encoding'],
-                security=_header['security']
+                security=_header['security'],
+                raw_bytes=_header['raw_bytes']
             )
         except KeyError:
             raise WrongJSONFormat

--- a/pymerkle/validations.py
+++ b/pymerkle/validations.py
@@ -34,11 +34,11 @@ def validateProof(target, proof):
     else:
 
         # Configure hashing parameters
-
         machine = hash_machine(
             hash_type=_header['hash_type'],
             encoding=_header['encoding'],
-            security=_header['security']
+            security=_header['security'],
+            raw_bytes=_header['raw_bytes']
         )
 
         # Perform hash-comparison


### PR DESCRIPTION
MerkleTree required always an encoding. However, this led to an issue when
hashing bytes without knowing the encoding. This fix adds a new "encoding"
set as an empty string '' that specifies that no encoding has been provided.

Thus the hashing of any byte is possible. Note that there still may be
representation issues when printing this information.
```
>>> from pymerkle import MerkleTree, validateProof, validationReceipt
>>> from pymerkle.proof import Proof
>>> tree = MerkleTree(raw_bytes=True)
>>> tree.update(b"hola")
>>> tree.update(b"\xc9")
>>> print(tree.rootHash)
>>> p = tree.auditProof(0).serialize()
>>> P = Proof(from_dict=p)
>>> print(validateProof(target=tree.rootHash, proof=P))
```
Output:
```
b'cfdcdbc8fe0cfe0df65f98bfed1309a0f43e2b2208040c6014ae19db4ea84901'
True
```